### PR TITLE
fix(mixnet): Incorrect if statement in mixnet

### DIFF
--- a/decide/mixnet/mixcrypt.py
+++ b/decide/mixnet/mixcrypt.py
@@ -140,21 +140,22 @@ class MixCrypt:
 
     def multiple_decrypt(self, msgs, last=True):
         msgs2 = []
-        if len(msgs[0]) == 2:
-            for a, b in msgs:
-                clear = self.decrypt((a, b))
-                if last:
-                    msg = clear
-                else:
-                    msg = (a, clear)
-                msgs2.append(msg)
-        elif len(msgs[0]) == 3:
+        if len(msgs[0]) == 3:
             for a, b, priority in msgs:
                 clear = self.decrypt((a, b))
                 if last:
                     msg = clear
                 else:
                     msg = (a, clear, priority)
+                msgs2.append(msg)
+
+        else:
+            for a, b in msgs:
+                clear = self.decrypt((a, b))
+                if last:
+                    msg = clear
+                else:
+                    msg = (a, clear)
                 msgs2.append(msg)
         return msgs2
 
@@ -171,6 +172,7 @@ class MixCrypt:
                 else:
                     msg = (a, clear, priority)  # Return a list of three elements
                 msgs3.append(msg)
+
         else:
             while msgs2:
                 n = random.StrongRandom().randint(0, len(msgs2) - 1)


### PR DESCRIPTION
An if statement in the mixnet module was causing some tests to fail. Now it's fixed and the tests should run properly again. This was probably because the msg parameter was only allowed to be 2 or 3 as length.


Disclaimer: I have assigned this PR to @auroranavas and @marnunrey2 because most of Zambrano-2 was busy.